### PR TITLE
Added basic image parsing and viewport size settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,30 @@ PhearJS accepts the following parameters:
 - **cache_namespace**=<*string*\>
   A namespace to use on the cache. Can be useful for multi-client settings.
   Default: *global-*.
-
+  
+- **viewport_width**=<*number*\>
+  Width in pixels. Default: 960
+  
+- **viewport_height**=<*number*\>
+  height in pixels. Default: 540
+  
+- **as_image**=[*false*|*true*]
+  Include `rendered` field to the response with the path to saved screenshot of the page.
+  Format, quality, path to save the screenshot can be set in `as_image_config`.
+  
+  ```
+        "as_image_config": {
+          "format": "PNG", // PNG and JPEG are recommended among others. 
+          "quality": 75, // details: http://phantomjs.org/api/webpage/method/render.html
+          "path": "screenshots/"
+        }
+  ```
+  
+  Images are saved by phantomJS on day-by-day basis with some unique names as: `screenshots/2016-07-31/01:05:25.116-c5fsf.PNG`
+  
+  Image rendering is not perfect. Just try `http://localhost:8100/?fetch_url=http://phantomjs.org&as_image=true` 
+  to see possible defects. Default: *false*.
+  
 ### Status page
 
 When PhearJS is running you can find a status page at `http://localhost:8100/status`. It

--- a/config/config.json
+++ b/config/config.json
@@ -19,7 +19,15 @@
         "user_agent": "PhearBot/0.4.1 - http://phear.io",
         "max_connections": 10,
         "get_requests": false,
-        "get_cookies": false
+        "get_cookies": false,
+        "viewport_width": 960,
+        "viewport_height": 540,
+        "as_image": false,
+        "as_image_config": {
+          "format": "PNG",
+          "quality": 75,
+          "path": "screenshots/"
+        }
       }
     },
     "production": {
@@ -47,7 +55,15 @@
         "max_connections": 10,
         "allowed_clients": ["127.0.0.1"],
         "get_requests": false,
-        "get_cookies": false
+        "get_cookies": false,
+        "viewport_width": 960,
+        "viewport_height": 540,
+        "as_image": false,
+        "as_image_config": {
+          "format": "PNG",
+          "quality": 75,
+          "path": "screenshots/"
+        }
       }
     }
   }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -5,7 +5,7 @@
     var server, service;
     server = webserver.create();
     service = server.listen(config.port, function(request, response) {
-      var err, error, error1, escaped_fetch_url, get_cookies, get_requests, parse_delay, parsed_fetch_url, ref, ref1, ref2, ref3, request_headers, request_url, this_inst;
+      var as_image, as_image_config, err, error, error1, escaped_fetch_url, get_cookies, get_requests, parse_delay, parsed_fetch_url, ref, ref1, ref2, ref3, ref4, ref5, ref6, request_headers, request_url, this_inst, viewport_height, viewport_width;
       this_inst = next_instance_number();
       this_inst = "worker:p-" + this_inst;
       logger.info(this_inst, "Spawn subprocess.");
@@ -30,6 +30,10 @@
       parse_delay = ((ref1 = request_url.query) != null ? ref1.parse_delay : void 0) || config.parse_delay;
       get_requests = ((ref2 = request_url.query) != null ? ref2.get_requests : void 0) || config.get_requests;
       get_cookies = ((ref3 = request_url.query) != null ? ref3.get_cookies : void 0) || config.get_cookies;
+      as_image = ((ref4 = request_url.query) != null ? ref4.as_image : void 0) || config.as_image;
+      as_image_config = config.as_image_config;
+      viewport_width = ((ref5 = request_url.query) != null ? ref5.viewport_width : void 0) || config.viewport_width;
+      viewport_height = ((ref6 = request_url.query) != null ? ref6.viewport_height : void 0) || config.viewport_height;
       request_headers = {};
       if (request_url.query.headers != null) {
         try {
@@ -41,7 +45,7 @@
       }
       logger.info(this_inst, "Fetching " + escaped_fetch_url + ".");
       try {
-        return fetch_url(escaped_fetch_url, response, this_inst, parse_delay, request_headers, get_requests, get_cookies);
+        return fetch_url(escaped_fetch_url, response, this_inst, parse_delay, request_headers, get_requests, get_cookies, as_image, as_image_config, viewport_width, viewport_height);
       } catch (error1) {
         err = error1;
         response.statusCode = 500;
@@ -53,7 +57,7 @@
     }
   };
 
-  fetch_url = function(url, response, this_inst, parse_delay, request_headers, get_requests, get_cookies) {
+  fetch_url = function(url, response, this_inst, parse_delay, request_headers, get_requests, get_cookies, as_image, as_image_config, viewport_width, viewport_height) {
     var cookie_inst, done, final_url, had_js_errors, headers, page_inst, requests;
     final_url = url;
     headers = {};
@@ -111,6 +115,10 @@
     };
     return page_inst.open(url, function(status) {
       var fetch_url_headers, i;
+      page_inst.viewportSize = {
+        width: viewport_width,
+        height: viewport_height
+      };
       if (done) {
         return true;
       } else {
@@ -130,6 +138,7 @@
         }
         response.setHeader("content-type", "application/json");
         return page_inst.parse_wait = setTimeout((function() {
+          var iso_date, path_to_image;
           if (!(page_inst != null ? page_inst.hasOwnProperty('content') : void 0)) {
             response.statusCode = 500;
             close_response(this_inst, "Rendering " + url + " failed.", response);
@@ -139,6 +148,14 @@
               cookie_inst.close();
             }
             return;
+          }
+          if (as_image) {
+            iso_date = new Date().toISOString();
+            path_to_image = "" + as_image_config.path + (iso_date.substr(0, 10)) + "/" + (iso_date.substr(11, 12)) + " - " + (Math.random().toString(36).substring(2, 7)) + "." + as_image_config.format;
+            page_inst.render(path_to_image, {
+              format: as_image_config.format,
+              quality: as_image_config.quality
+            });
           }
           response.statusCode = 200;
           response.write(JSON.stringify({
@@ -150,7 +167,8 @@
             requests: get_requests === "true" || get_requests === "1" ? requests : void 0,
             cookies: get_cookies === "true" || get_cookies === "1" ? cookie_inst.cookies : void 0,
             had_js_errors: had_js_errors,
-            content: strip_scripts(page_inst.content)
+            content: strip_scripts(page_inst.content),
+            rendered: path_to_image
           }));
           close_response(this_inst, status, response);
           page_inst.close();


### PR DESCRIPTION
Based on #6 

Concerns:
- specifying viewport size is a really nice and useful feature. As for now we don't know at what screen size PhantomJS runs (As I can understand the default width is 960px, as I see from image screenshots when the width and height are  not specified, but from the other hand [here](https://github.com/ariya/phantomjs/blob/master/src/webpage.cpp#L442) I see 400x300, and [here](https://github.com/Vitallium/qtbase/blob/b5cc0083a5766e773885e8dd624c51a967c17de0/src/plugins/platforms/phantom/phantomintegration.cpp#L94) 1024x768). One can say that the browser is headless, so why do we need to specify the dimensions? But actually I think we should! Sites can behave completely different for different dimensions.
- phantomJS has not so rich fs api as nodeJS, so filename generation is rather primitive. Deletion of `screenshots` folder on some schedule is not implemented, but it is a trivial task to do.
- also I do not like the number of attributes for `fetch_url` function, but refactoring the CoffeeScript code is not for Sunday night :)
